### PR TITLE
fix changelog release version from 1.1.0 to 1.0.1 & relax version bounds

### DIFF
--- a/servant-jsonrpc-client/changelog.md
+++ b/servant-jsonrpc-client/changelog.md
@@ -1,3 +1,10 @@
+# 1.1.0
+
+* Relax upper version bounds for `aeson` to `(>= 1.3 && < 1.6)`
+* Relax upper version bounds for `base` to `(>= 4.11 && < 5.0)`
+* Relax upper version bounds for `servant` to `(>= 0.14 && < 0.19)`
+* Relax upper version bounds for `servant-client-core` to `(>= 0.14 && < 0.19)`
+
 # 1.0.1
 
 Adds a `HasClient` instance for `RawJsonRpc`

--- a/servant-jsonrpc-client/servant-jsonrpc-client.cabal
+++ b/servant-jsonrpc-client/servant-jsonrpc-client.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.4
 
 name:                servant-jsonrpc-client
-version:             1.0.1
+version:             1.1.0
 author:              Ian Shipman <ics@gambolingpangolin.com>
 maintainer:          Ian Shipman <ics@gambolingpangolin.com>
 
@@ -30,8 +30,8 @@ library
     Servant.Client.JsonRpc
 
   build-depends:
-      aeson                         >= 1.3          && < 1.5
-    , base                          >= 4.11         && < 4.13
-    , servant                       >= 0.14         && < 0.17
-    , servant-client-core           >= 0.14         && < 0.17
-    , servant-jsonrpc               >= 1.0.1        && < 1.1
+      aeson                         >= 1.3          && < 1.6
+    , base                          >= 4.11         && < 5.0
+    , servant                       >= 0.14         && < 0.19
+    , servant-client-core           >= 0.14         && < 0.19
+    , servant-jsonrpc               >= 1.0.1        && < 1.2

--- a/servant-jsonrpc-examples/servant-jsonrpc-examples.cabal
+++ b/servant-jsonrpc-examples/servant-jsonrpc-examples.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.4
 
 name:                servant-jsonrpc-examples
-version:             1.0.0
+version:             1.1.0
 author:              Ian Shipman <ics@gambolingpangolin.com>
 maintainer:          Ian Shipman <ics@gambolingpangolin.com>
 synopsis:            Example client and server for servant-jsonrpc
@@ -21,9 +21,9 @@ source-repository head
 common deps
   default-language: Haskell2010
   build-depends:
-      aeson                     >= 1.3              && < 1.5
-    , base                      >= 4.11             && < 4.13
-    , servant                   >= 0.14             && < 0.17
+      aeson                     >= 1.3              && < 1.6
+    , base                      >= 4.11             && < 5.0
+    , servant                   >= 0.14             && < 0.19
     , servant-jsonrpc
 
 library

--- a/servant-jsonrpc-server/changelog.md
+++ b/servant-jsonrpc-server/changelog.md
@@ -1,3 +1,10 @@
+# 2.1.0
+
+* Relax upper version bounds for `aeson` to `(>= 1.3 && < 1.6)`
+* Relax upper version bounds for `base` to `(>= 4.11 && < 5.0)`
+* Relax upper version bounds for `servant` to `(>= 0.14 && < 0.19)`
+* Relax upper version bounds for `servant-server` to `(>= 0.14 && < 0.19)`
+
 # 2.0.0
 
 The previous version was hopelessly broken.  This completely replaces it.

--- a/servant-jsonrpc-server/servant-jsonrpc-server.cabal
+++ b/servant-jsonrpc-server/servant-jsonrpc-server.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.4
 
 name:                servant-jsonrpc-server
-version:             2.0.0
+version:             2.1.0
 author:              Ian Shipman <ics@gambolingpangolin.com>
 maintainer:          Ian Shipman <ics@gambolingpangolin.com>
 
@@ -30,10 +30,10 @@ library
     Servant.Server.JsonRpc
 
   build-depends:
-      aeson                 >= 1.3          && < 1.5
-    , base                  >= 4.11         && < 4.13
+      aeson                 >= 1.3          && < 1.6
+    , base                  >= 4.11         && < 5.0
     , containers            >= 0.5          && < 0.7
     , mtl                   >= 2.2          && < 2.3
-    , servant               >= 0.14         && < 0.17
-    , servant-jsonrpc       >= 1.0.1        && < 1.1
-    , servant-server        >= 0.14         && < 0.17
+    , servant               >= 0.14         && < 0.19
+    , servant-jsonrpc       >= 1.0.1        && < 1.2
+    , servant-server        >= 0.14         && < 0.19

--- a/servant-jsonrpc/changelog.md
+++ b/servant-jsonrpc/changelog.md
@@ -1,5 +1,11 @@
 # 1.1.0
 
+* Relax upper version bounds for `aeson` to `(>= 1.3 && < 1.6)`
+* Relax upper version bounds for `base` to `(>= 4.11 && < 5.0)`
+* Relax upper version bounds for `servant` to `(>= 0.14 && < 0.19)`
+
+# 1.0.1
+
 Adds standard error codes to the library.
 
 # 1.0.0

--- a/servant-jsonrpc/servant-jsonrpc.cabal
+++ b/servant-jsonrpc/servant-jsonrpc.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.4
 
 name:                servant-jsonrpc
-version:             1.0.1
+version:             1.1.0
 author:              Ian Shipman <ics@gambolingpangolin.com>
 maintainer:          Ian Shipman <ics@gambolingpangolin.com>
 
@@ -33,6 +33,6 @@ library
     Servant.JsonRpc
 
   build-depends:
-      aeson                     >= 1.3              && < 1.5
-    , base                      >= 4.11             && < 4.13
-    , servant                   >= 0.14             && < 0.17
+      aeson                     >= 1.3              && < 1.6
+    , base                      >= 4.11             && < 5.0
+    , servant                   >= 0.14             && < 0.19


### PR DESCRIPTION
I notice that servant-jsonrpc/servant-jsonrpc has a release version `1.0.1` in [cabal file](https://github.com/bitnomial/servant-jsonrpc/blob/master/servant-jsonrpc/servant-jsonrpc.cabal#L4) while a release version `1.1.0` in [changelog.md](https://github.com/bitnomial/servant-jsonrpc/blob/master/servant-jsonrpc/changelog.md#110)