### PR TITLE
Adds JSON-RPC mime type

### DIFF
--- a/servant-jsonrpc-client/servant-jsonrpc-client.cabal
+++ b/servant-jsonrpc-client/servant-jsonrpc-client.cabal
@@ -32,6 +32,6 @@ library
   build-depends:
       aeson                         >= 1.3          && < 1.6
     , base                          >= 4.11         && < 5.0
-    , servant                       >= 0.14         && < 0.19
-    , servant-client-core           >= 0.14         && < 0.19
+    , servant                       >= 0.14         && < 0.20
+    , servant-client-core           >= 0.14         && < 0.20
     , servant-jsonrpc               >= 1.0.1        && < 1.2

--- a/servant-jsonrpc-examples/servant-jsonrpc-examples.cabal
+++ b/servant-jsonrpc-examples/servant-jsonrpc-examples.cabal
@@ -21,9 +21,9 @@ source-repository head
 common deps
   default-language: Haskell2010
   build-depends:
-      aeson                     >= 1.3              && < 1.6
+      aeson                     >= 1.3              && < 2.1
     , base                      >= 4.11             && < 5.0
-    , servant                   >= 0.14             && < 0.19
+    , servant                   >= 0.14             && < 0.20
     , servant-jsonrpc
 
 library

--- a/servant-jsonrpc-server/servant-jsonrpc-server.cabal
+++ b/servant-jsonrpc-server/servant-jsonrpc-server.cabal
@@ -30,10 +30,9 @@ library
     Servant.Server.JsonRpc
 
   build-depends:
-      aeson                 >= 1.3          && < 1.6
+      aeson                 >= 1.3          && < 2.1
     , base                  >= 4.11         && < 5.0
     , containers            >= 0.5          && < 0.7
-    , mtl                   >= 2.2          && < 2.3
-    , servant               >= 0.14         && < 0.19
+    , servant               >= 0.14         && < 0.20
     , servant-jsonrpc       >= 1.0.1        && < 1.2
-    , servant-server        >= 0.14         && < 0.19
+    , servant-server        >= 0.14         && < 0.20

--- a/servant-jsonrpc-server/src/Servant/Server/JsonRpc.hs
+++ b/servant-jsonrpc-server/src/Servant/Server/JsonRpc.hs
@@ -47,12 +47,15 @@ import           Data.Map.Strict          (Map)
 import qualified Data.Map.Strict          as Map
 import           Data.Proxy               (Proxy (..))
 import           GHC.TypeLits             (KnownSymbol, symbolVal)
-import           Servant.API              ((:<|>) (..), (:>), JSON,
-                                           NoContent (..), Post, ReqBody)
+import           Servant.API              (NoContent (..), Post, ReqBody,
+                                           (:<|>) (..), (:>))
 import           Servant.API.ContentTypes (AllCTRender (..))
 
 #if MIN_VERSION_servant_server(0,18,0)
-import           Servant.Server           (Handler, HasServer (..), HasContextEntry, type (.++), DefaultErrorFormatters, ErrorFormatters)
+import           Servant.Server           (DefaultErrorFormatters,
+                                           ErrorFormatters, Handler,
+                                           HasContextEntry, HasServer (..),
+                                           type (.++))
 #elif MIN_VERSION_servant_server(0,14,0)
 import           Servant.Server           (Handler, HasServer (..))
 #endif
@@ -65,7 +68,7 @@ import           Servant.JsonRpc
 data PossibleContent a = SomeContent a | EmptyContent
 
 
-instance ToJSON a => AllCTRender '[JSON] (PossibleContent a) where
+instance ToJSON a => AllCTRender '[JSONRPC] (PossibleContent a) where
     handleAcceptH px h = \case
         SomeContent x -> handleAcceptH px h x
         EmptyContent  -> handleAcceptH px h NoContent
@@ -75,8 +78,8 @@ type PossibleJsonRpcResponse = PossibleContent (JsonRpcResponse Value Value)
 
 
 type RawJsonRpcEndpoint
-    = ReqBody '[JSON] (Request Value)
-   :> Post '[JSON] PossibleJsonRpcResponse
+    = ReqBody '[JSONRPC] (Request Value)
+   :> Post '[JSONRPC] PossibleJsonRpcResponse
 
 
 #if MIN_VERSION_servant_server(0,18,0)

--- a/servant-jsonrpc/changelog.md
+++ b/servant-jsonrpc/changelog.md
@@ -1,3 +1,8 @@
+# 1.1.1
+
+* Allow "application/json-rpc" as the content type
+* Accept string for the `id` field
+
 # 1.1.0
 
 * Relax upper version bounds for `aeson` to `(>= 1.3 && < 1.6)`

--- a/servant-jsonrpc/servant-jsonrpc.cabal
+++ b/servant-jsonrpc/servant-jsonrpc.cabal
@@ -33,8 +33,8 @@ library
     Servant.JsonRpc
 
   build-depends:
-      aeson                     >= 1.3              && < 1.6
+      aeson                     >= 1.3              && < 2.1
     , base                      >= 4.11             && < 5.0
     , http-media                >= 0.7.1.3          && < 0.9
-    , servant                   >= 0.14             && < 0.19
-    , text                     ^>= 1.2
+    , servant                   >= 0.14             && < 0.20
+    , text                      >= 1.2              && < 2.1

--- a/servant-jsonrpc/servant-jsonrpc.cabal
+++ b/servant-jsonrpc/servant-jsonrpc.cabal
@@ -36,3 +36,4 @@ library
       aeson                     >= 1.3              && < 1.6
     , base                      >= 4.11             && < 5.0
     , servant                   >= 0.14             && < 0.19
+    , http-media                >= 0.7.1.3          && < 0.9

--- a/servant-jsonrpc/servant-jsonrpc.cabal
+++ b/servant-jsonrpc/servant-jsonrpc.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.4
 
 name:                servant-jsonrpc
-version:             1.1.0
+version:             1.1.1
 author:              Ian Shipman <ics@gambolingpangolin.com>
 maintainer:          Ian Shipman <ics@gambolingpangolin.com>
 
@@ -35,5 +35,6 @@ library
   build-depends:
       aeson                     >= 1.3              && < 1.6
     , base                      >= 4.11             && < 5.0
-    , servant                   >= 0.14             && < 0.19
     , http-media                >= 0.7.1.3          && < 0.9
+    , servant                   >= 0.14             && < 0.19
+    , text                     ^>= 1.2


### PR DESCRIPTION
This change defines a new MIME type for compatibility with a wider range of clients and servers.  It also relaxes the requirement that the id of a message is a JSON number.  In addition, I updated the dependencies.