### PR TITLE
Check in correct stack.yaml.lock

### DIFF
--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -9,5 +9,4 @@ snapshots:
     size: 618876
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/6.yaml
     sha256: fb634b19f31da06684bb07ce02a20c75a3162138f279b388905b03ebd57bb50f
-  original:
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/6.yaml
+  original: lts-19.6


### PR DESCRIPTION
The old stack.yaml.lock was checked in with the long git path to the release, this corrects it to use the shortened stackage name to match what's in the stack.yaml, this is what is generated from a `stack build`