### PR TITLE
Re-enable JSON (opt-in only) alongside JSONRPC

### DIFF
--- a/servant-jsonrpc-client/servant-jsonrpc-client.cabal
+++ b/servant-jsonrpc-client/servant-jsonrpc-client.cabal
@@ -28,6 +28,7 @@ library
 
   exposed-modules:
     Servant.Client.JsonRpc
+    Servant.Client.JsonRpc.ContentType
 
   build-depends:
       aeson                         >= 1.3          && < 2.1

--- a/servant-jsonrpc-client/src/Servant/Client/JsonRpc.hs
+++ b/servant-jsonrpc-client/src/Servant/Client/JsonRpc.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -24,11 +25,11 @@ module Servant.Client.JsonRpc
 import           Data.Aeson          (FromJSON, ToJSON)
 import           Data.Proxy          (Proxy (..))
 import           GHC.TypeLits        (KnownSymbol, symbolVal)
-import           Servant.API         (NoContent)
+import           Servant.API         (NoContent, JSON)
 import           Servant.Client.Core (HasClient (..), RunClient)
 
+import           Servant.Client.JsonRpc.ContentType
 import           Servant.JsonRpc
-
 
 -- | The 'RawJsonRpc' construct is completely transparent to clients
 instance (RunClient m, HasClient m api) => HasClient m (RawJsonRpc api) where
@@ -36,37 +37,89 @@ instance (RunClient m, HasClient m api) => HasClient m (RawJsonRpc api) where
     clientWithRoute pxm _  = clientWithRoute pxm (Proxy @api)
     hoistClientMonad pxm _ = hoistClientMonad pxm (Proxy @api)
 
-
+-- | Forwarding instance, picks JSONRPC as the defau;t
 instance (RunClient m, KnownSymbol method, ToJSON p, FromJSON e, FromJSON r)
     => HasClient m (JsonRpc method p e r) where
 
     type Client m (JsonRpc method p e r)
+        = Client m (UsingContentType JSONRPC (JsonRpc method p e r))
+
+    clientWithRoute pm _ =
+        clientWithRoute
+          pm
+          (Proxy @(UsingContentType JSON (JsonRpc method p e r)))
+
+    hoistClientMonad pm _ hoist =
+        hoistClientMonad
+          pm
+          (Proxy @(UsingContentType JSON (JsonRpc method p e r)))
+          hoist
+
+instance ( RunClient m
+         , KnownSymbol method
+         , ToJSON p
+         , FromJSON e
+         , FromJSON r
+         , IsSupportedContentType ctyp
+         )
+    => HasClient m (UsingContentType ctyp (JsonRpc method p e r)) where
+
+    type Client m (UsingContentType ctyp (JsonRpc method p e r))
         = p -> m (JsonRpcResponse e r)
 
     clientWithRoute _ _ req p =
         client req jsonRpcRequest
 
         where
-        client = clientWithRoute (Proxy @m) endpoint
+        client = case isSupportedContentType (Proxy @ctyp) of
+                   SupportedContentTypeJSON ->
+                     clientWithRoute (Proxy @m) endpoint
+                   SupportedContentTypeJSONRPC ->
+                     clientWithRoute (Proxy @m) endpoint
         jsonRpcRequest = Request (symbolVal $ Proxy @method) p (Just 0)
 
-        endpoint = Proxy @(JsonRpcEndpoint (JsonRpc method p e r))
+        endpoint = Proxy @(JsonRpcEndpoint ctyp (JsonRpc method p e r))
 
     hoistClientMonad _ _ f x p = f $ x p
 
-
+-- | Forwarding instance, picks JSONRPC as the defau;t
 instance (RunClient m, KnownSymbol method, ToJSON p)
     => HasClient m (JsonRpcNotification method p) where
 
     type Client m (JsonRpcNotification method p)
+        = Client m (UsingContentType JSONRPC (JsonRpcNotification method p))
+
+    clientWithRoute pm _ =
+        clientWithRoute
+          pm
+          (Proxy @(UsingContentType JSONRPC (JsonRpcNotification method p)))
+
+    hoistClientMonad pm _ hoist =
+        hoistClientMonad
+          pm
+          (Proxy @(UsingContentType JSONRPC (JsonRpcNotification method p)))
+          hoist
+
+instance ( RunClient m
+         , KnownSymbol method
+         , ToJSON p
+         , IsSupportedContentType ctyp
+         )
+    => HasClient m (UsingContentType ctyp (JsonRpcNotification method p)) where
+
+    type Client m (UsingContentType ctyp (JsonRpcNotification method p))
         = p -> m NoContent
 
     clientWithRoute _ _ req p =
         client req jsonRpcRequest
         where
-        client = clientWithRoute (Proxy @m) endpoint
+        client = case isSupportedContentType (Proxy @ctyp) of
+                   SupportedContentTypeJSON ->
+                     clientWithRoute (Proxy @m) endpoint
+                   SupportedContentTypeJSONRPC ->
+                     clientWithRoute (Proxy @m) endpoint
         jsonRpcRequest = Request (symbolVal $ Proxy @method) p Nothing
 
-        endpoint = Proxy @(JsonRpcEndpoint (JsonRpcNotification method p))
+        endpoint = Proxy @(JsonRpcEndpoint ctyp (JsonRpcNotification method p))
 
     hoistClientMonad _ _ f x p = f $ x p

--- a/servant-jsonrpc-client/src/Servant/Client/JsonRpc/ContentType.hs
+++ b/servant-jsonrpc-client/src/Servant/Client/JsonRpc/ContentType.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+module Servant.Client.JsonRpc.ContentType
+  ( UsingContentType
+  , SupportedContentType(..)
+  , IsSupportedContentType(..)
+  ) where
+
+import Data.Proxy
+import Servant.API.ContentTypes
+import Servant.Client.Core
+import Servant.JsonRpc
+import Servant.API
+
+-- | Manually specify the content type
+--
+-- Defaults to JSONRPC.
+data UsingContentType ctyp a
+
+data SupportedContentType ctyp where
+  SupportedContentTypeJSON    :: SupportedContentType JSON
+  SupportedContentTypeJSONRPC :: SupportedContentType JSONRPC
+
+class IsSupportedContentType ctyp where
+  isSupportedContentType :: Proxy ctyp -> SupportedContentType ctyp
+
+instance IsSupportedContentType JSON where
+  isSupportedContentType _ = SupportedContentTypeJSON
+instance IsSupportedContentType JSONRPC where
+  isSupportedContentType _ = SupportedContentTypeJSONRPC
+
+-- | Distribute 'UsingContentType' over '(:<>)'
+instance ( RunClient m
+         , HasClient m (UsingContentType ctyp a)
+         , HasClient m (UsingContentType ctyp b)
+         )
+  => HasClient m (UsingContentType ctyp (a :<|> b)) where
+
+  type Client m (UsingContentType ctyp (a :<|> b))
+      = Client m (UsingContentType ctyp a :<|> UsingContentType ctyp b)
+
+  clientWithRoute pm _ =
+    clientWithRoute
+      pm
+      (Proxy @(UsingContentType ctyp a :<|> UsingContentType ctyp b))
+
+  hoistClientMonad pm _ hoist =
+    hoistClientMonad
+      pm
+      (Proxy @(UsingContentType ctyp a :<|> UsingContentType ctyp b))
+      hoist
+

--- a/servant-jsonrpc/src/Servant/JsonRpc.hs
+++ b/servant-jsonrpc/src/Servant/JsonRpc.hs
@@ -198,12 +198,12 @@ data JsonRpc (method :: Symbol) p e r
 data JsonRpcNotification (method :: Symbol) p
 
 
-type family JsonRpcEndpoint a where
-    JsonRpcEndpoint (JsonRpc m p e r)
-        = ReqBody '[JSONRPC] (Request p) :> Post '[JSONRPC] (JsonRpcResponse e r)
+type family JsonRpcEndpoint ctyp a where
+    JsonRpcEndpoint ctyp (JsonRpc m p e r)
+        = ReqBody '[ctyp] (Request p) :> Post '[ctyp] (JsonRpcResponse e r)
 
-    JsonRpcEndpoint (JsonRpcNotification m p)
-        = ReqBody '[JSONRPC] (Request p) :> Post '[JSONRPC] NoContent
+    JsonRpcEndpoint ctyp (JsonRpcNotification m p)
+        = ReqBody '[ctyp] (Request p) :> Post '[ctyp] NoContent
 
 -- | The JSON-RPC content type
 data JSONRPC


### PR DESCRIPTION
This introduces a combinator `UsingContentType` that allows client code to explicitly specify the content type they would like. This is backwards compatible: unless explicitly specified, the default is still `JSONRPC`, like it is now.

`UsingContentType` also has its own `HasClient` instance for `(:<|>)`; this makes it possible to define an API without specifying the content type, and then at the top-level wrap the entire thing in a single call to `UsingContentType`.