### PR TITLE
Update aeson dependency to build on GHC 9.4.4

### DIFF
--- a/servant-jsonrpc-client/servant-jsonrpc-client.cabal
+++ b/servant-jsonrpc-client/servant-jsonrpc-client.cabal
@@ -30,7 +30,7 @@ library
     Servant.Client.JsonRpc
 
   build-depends:
-      aeson                         >= 1.3          && < 2.1
+      aeson                         >= 1.3          && < 2.2
     , base                          >= 4.11         && < 5.0
     , servant                       >= 0.14         && < 0.20
     , servant-client-core           >= 0.14         && < 0.20

--- a/servant-jsonrpc-examples/client/Main.hs
+++ b/servant-jsonrpc-examples/client/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-unused-do-bind #-}
 
 module Main where
 

--- a/servant-jsonrpc-examples/servant-jsonrpc-examples.cabal
+++ b/servant-jsonrpc-examples/servant-jsonrpc-examples.cabal
@@ -21,7 +21,7 @@ source-repository head
 common deps
   default-language: Haskell2010
   build-depends:
-      aeson                     >= 1.3              && < 2.1
+      aeson                     >= 1.3              && < 2.2
     , base                      >= 4.11             && < 5.0
     , servant                   >= 0.14             && < 0.20
     , servant-jsonrpc

--- a/servant-jsonrpc-server/servant-jsonrpc-server.cabal
+++ b/servant-jsonrpc-server/servant-jsonrpc-server.cabal
@@ -30,7 +30,7 @@ library
     Servant.Server.JsonRpc
 
   build-depends:
-      aeson                 >= 1.3          && < 2.1
+      aeson                 >= 1.3          && < 2.2
     , base                  >= 4.11         && < 5.0
     , containers            >= 0.5          && < 0.7
     , servant               >= 0.14         && < 0.20

--- a/servant-jsonrpc-server/servant-jsonrpc-server.cabal
+++ b/servant-jsonrpc-server/servant-jsonrpc-server.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.4
 
 name:                servant-jsonrpc-server
-version:             2.1.1
+version:             2.1.2
 author:              Ian Shipman <ics@gambolingpangolin.com>
 maintainer:          Ian Shipman <ics@gambolingpangolin.com>
 

--- a/servant-jsonrpc-server/src/Servant/Server/JsonRpc.hs
+++ b/servant-jsonrpc-server/src/Servant/Server/JsonRpc.hs
@@ -43,6 +43,7 @@ module Servant.Server.JsonRpc
 import           Data.Aeson               (FromJSON (..), ToJSON (..), Value)
 import           Data.Aeson.Types         (parseEither)
 import           Data.Bifunctor           (bimap)
+import           Data.Kind                (Type)
 import           Data.Map.Strict          (Map)
 import qualified Data.Map.Strict          as Map
 import           Data.Proxy               (Proxy (..))
@@ -99,7 +100,7 @@ instance RouteJsonRpc api => HasServer (RawJsonRpc api) context where
 
 -- | This internal class is how we accumulate a map of handlers for dispatch
 class RouteJsonRpc a where
-    type RpcHandler a (m :: * -> *)
+    type RpcHandler a (m :: Type -> Type)
     jsonRpcRouter
         :: Monad m => Proxy a -> Proxy m -> RpcHandler a m
         -> Map String (Value -> m (PossibleContent (Either (JsonRpcErr Value) Value)))

--- a/servant-jsonrpc/servant-jsonrpc.cabal
+++ b/servant-jsonrpc/servant-jsonrpc.cabal
@@ -33,7 +33,7 @@ library
     Servant.JsonRpc
 
   build-depends:
-      aeson                     >= 1.3              && < 2.1
+      aeson                     >= 1.3              && < 2.2
     , base                      >= 4.11             && < 5.0
     , http-media                >= 0.7.1.3          && < 0.9
     , servant                   >= 0.14             && < 0.20


### PR DESCRIPTION
This makes everything work ok on GHC 9.4.4, even the examples run fine.

I also tried to make it build with GHC 9.6.1 but Servant doesn't build with it yet so
we'll need to wait on that.