### PR TITLE
Update servant version constraints

### DIFF
--- a/servant-jsonrpc-client/servant-jsonrpc-client.cabal
+++ b/servant-jsonrpc-client/servant-jsonrpc-client.cabal
@@ -32,6 +32,6 @@ library
   build-depends:
       aeson                         >= 1.3          && < 2.2
     , base                          >= 4.11         && < 5.0
-    , servant                       >= 0.14         && < 0.20
-    , servant-client-core           >= 0.14         && < 0.20
+    , servant                       >= 0.14         && < 0.21
+    , servant-client-core           >= 0.14         && < 0.21
     , servant-jsonrpc               >= 1.0.1        && < 1.2

--- a/servant-jsonrpc-examples/servant-jsonrpc-examples.cabal
+++ b/servant-jsonrpc-examples/servant-jsonrpc-examples.cabal
@@ -23,7 +23,7 @@ common deps
   build-depends:
       aeson                     >= 1.3              && < 2.2
     , base                      >= 4.11             && < 5.0
-    , servant                   >= 0.14             && < 0.20
+    , servant                   >= 0.14             && < 0.21
     , servant-jsonrpc
 
 library

--- a/servant-jsonrpc-server/servant-jsonrpc-server.cabal
+++ b/servant-jsonrpc-server/servant-jsonrpc-server.cabal
@@ -33,6 +33,6 @@ library
       aeson                 >= 1.3          && < 2.2
     , base                  >= 4.11         && < 5.0
     , containers            >= 0.5          && < 0.7
-    , servant               >= 0.14         && < 0.20
+    , servant               >= 0.14         && < 0.21
     , servant-jsonrpc       >= 1.0.1        && < 1.2
-    , servant-server        >= 0.14         && < 0.20
+    , servant-server        >= 0.14         && < 0.21

--- a/servant-jsonrpc/servant-jsonrpc.cabal
+++ b/servant-jsonrpc/servant-jsonrpc.cabal
@@ -36,5 +36,5 @@ library
       aeson                     >= 1.3              && < 2.2
     , base                      >= 4.11             && < 5.0
     , http-media                >= 0.7.1.3          && < 0.9
-    , servant                   >= 0.14             && < 0.20
+    , servant                   >= 0.14             && < 0.21
     , text                      >= 1.2              && < 2.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-19.6
+resolver: lts-21.22
 
 packages:
 - servant-jsonrpc

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 618876
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/6.yaml
-    sha256: fb634b19f31da06684bb07ce02a20c75a3162138f279b388905b03ebd57bb50f
-  original: lts-19.6
+    sha256: afd5ba64ab602cabc2d3942d3d7e7dd6311bc626dcb415b901eaf576cb62f0ea
+    size: 640060
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/22.yaml
+  original: lts-21.22


### PR DESCRIPTION
# description
- updated the stack resolver to the current LTS
- updated the package constraints for servant for compatibility with stackage nightly (which is currently on GHC 9.6)