### PR TITLE
Relaxes version bounds

### DIFF
--- a/servant-jsonrpc-client/servant-jsonrpc-client.cabal
+++ b/servant-jsonrpc-client/servant-jsonrpc-client.cabal
@@ -30,7 +30,7 @@ library
     Servant.Client.JsonRpc
 
   build-depends:
-      aeson                         >= 1.3          && < 2.2
+      aeson                         >= 1.3          && < 2.3
     , base                          >= 4.11         && < 5.0
     , servant                       >= 0.14         && < 0.21
     , servant-client-core           >= 0.14         && < 0.21

--- a/servant-jsonrpc-examples/servant-jsonrpc-examples.cabal
+++ b/servant-jsonrpc-examples/servant-jsonrpc-examples.cabal
@@ -21,7 +21,7 @@ source-repository head
 common deps
   default-language: Haskell2010
   build-depends:
-      aeson                     >= 1.3              && < 2.2
+      aeson                     >= 1.3              && < 2.3
     , base                      >= 4.11             && < 5.0
     , servant                   >= 0.14             && < 0.21
     , servant-jsonrpc

--- a/servant-jsonrpc-server/servant-jsonrpc-server.cabal
+++ b/servant-jsonrpc-server/servant-jsonrpc-server.cabal
@@ -30,9 +30,9 @@ library
     Servant.Server.JsonRpc
 
   build-depends:
-      aeson                 >= 1.3          && < 2.2
+      aeson                 >= 1.3          && < 2.3
     , base                  >= 4.11         && < 5.0
-    , containers            >= 0.5          && < 0.7
+    , containers            >= 0.5          && < 0.8
     , servant               >= 0.14         && < 0.21
     , servant-jsonrpc       >= 1.0.1        && < 1.2
     , servant-server        >= 0.14         && < 0.21

--- a/servant-jsonrpc/servant-jsonrpc.cabal
+++ b/servant-jsonrpc/servant-jsonrpc.cabal
@@ -33,8 +33,8 @@ library
     Servant.JsonRpc
 
   build-depends:
-      aeson                     >= 1.3              && < 2.2
+      aeson                     >= 1.3              && < 2.3
     , base                      >= 4.11             && < 5.0
     , http-media                >= 0.7.1.3          && < 0.9
     , servant                   >= 0.14             && < 0.21
-    , text                      >= 1.2              && < 2.1
+    , text                      >= 1.2              && < 2.2


### PR DESCRIPTION
This change increases top version bounds for some dependencies.  I made it sure it builds at the highest version numbers and that example runs.