### PR TITLE
Use fourmolu for formatting

### DIFF
--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,0 +1,50 @@
+# Number of spaces per indentation step
+indentation: 2
+
+# Styling of arrows in type signatures (choices: trailing, leading, or leading-args)
+function-arrows: trailing
+
+# How to place commas in multi-line lists, records, etc. (choices: leading or trailing)
+comma-style: leading
+
+# Styling of import/export lists (choices: leading, trailing, or diff-friendly)
+import-export-style: diff-friendly
+
+# Whether to full-indent or half-indent 'where' bindings past the preceding body
+indent-wheres: false
+
+# Whether to leave a space before an opening record brace
+record-brace-space: false
+
+# Number of spaces between top-level declarations
+newlines-between-decls: 1
+
+# How to print Haddock comments (choices: single-line, multi-line, or multi-line-compact)
+haddock-style: multi-line
+
+# How to print module docstring
+haddock-style-module: null
+
+# Styling of let blocks (choices: auto, inline, newline, or mixed)
+let-style: auto
+
+# How to align the 'in' keyword with respect to the 'let' keyword (choices: left-align, right-align, or no-space)
+in-style: right-align
+
+# Whether to put parentheses around a single constraint (choices: auto, always, or never)
+single-constraint-parens: always
+
+# Whether to put parentheses around a single deriving class (choices: auto, always, or never)
+single-deriving-parens: always
+
+# Output Unicode syntax (choices: detect, always, or never)
+unicode: never
+
+# Give the programmer more choice on where to insert blank lines
+respectful: true
+
+# Fixity information for operators
+fixities: []
+
+# Module reexports Fourmolu should know about
+reexports: []

--- a/servant-jsonrpc-client/Setup.hs
+++ b/servant-jsonrpc-client/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+
 main = defaultMain

--- a/servant-jsonrpc-client/src/Servant/Client/JsonRpc.hs
+++ b/servant-jsonrpc-client/src/Servant/Client/JsonRpc.hs
@@ -1,72 +1,72 @@
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
-
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
--- |
--- Module: Servant.Client.JsonRpc
---
--- This module provides support for generating JSON-RPC clients in the Servant framework.
---
--- > type Mul = JsonRpc "mul" (Int, Int) String Int
--- > mul :: (Int, Int) -> ClientM (JsonRpcResponse String Int)
--- > mul = client $ Proxy @Mul
---
--- Note: This client implementation runs over HTTP and the semantics of HTTP
--- remove the need for the message id.
-module Servant.Client.JsonRpc
-    ( module Servant.JsonRpc
-    ) where
+{- |
+Module: Servant.Client.JsonRpc
 
-import           Data.Aeson          (FromJSON, ToJSON)
-import           Data.Proxy          (Proxy (..))
-import           GHC.TypeLits        (KnownSymbol, symbolVal)
-import           Servant.API         (NoContent)
-import           Servant.Client.Core (HasClient (..), RunClient)
+This module provides support for generating JSON-RPC clients in the Servant framework.
 
-import           Servant.JsonRpc
+> type Mul = JsonRpc "mul" (Int, Int) String Int
+> mul :: (Int, Int) -> ClientM (JsonRpcResponse String Int)
+> mul = client $ Proxy @Mul
 
+Note: This client implementation runs over HTTP and the semantics of HTTP
+remove the need for the message id.
+-}
+module Servant.Client.JsonRpc (
+  module Servant.JsonRpc,
+) where
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Proxy (Proxy (..))
+import GHC.TypeLits (KnownSymbol, symbolVal)
+import Servant.API (NoContent)
+import Servant.Client.Core (HasClient (..), RunClient)
+
+import Servant.JsonRpc
 
 -- | The 'RawJsonRpc' construct is completely transparent to clients
 instance (RunClient m, HasClient m api) => HasClient m (RawJsonRpc api) where
-    type Client m (RawJsonRpc api) = Client m api
-    clientWithRoute pxm _  = clientWithRoute pxm (Proxy @api)
-    hoistClientMonad pxm _ = hoistClientMonad pxm (Proxy @api)
+  type Client m (RawJsonRpc api) = Client m api
+  clientWithRoute pxm _ = clientWithRoute pxm (Proxy @api)
+  hoistClientMonad pxm _ = hoistClientMonad pxm (Proxy @api)
 
+instance
+  (RunClient m, KnownSymbol method, ToJSON p, FromJSON e, FromJSON r) =>
+  HasClient m (JsonRpc method p e r)
+  where
+  type
+    Client m (JsonRpc method p e r) =
+      p -> m (JsonRpcResponse e r)
 
-instance (RunClient m, KnownSymbol method, ToJSON p, FromJSON e, FromJSON r)
-    => HasClient m (JsonRpc method p e r) where
+  clientWithRoute _ _ req p =
+    client req jsonRpcRequest
+   where
+    client = clientWithRoute (Proxy @m) endpoint
+    jsonRpcRequest = Request (symbolVal $ Proxy @method) p (Just 0)
 
-    type Client m (JsonRpc method p e r)
-        = p -> m (JsonRpcResponse e r)
+    endpoint = Proxy @(JsonRpcEndpoint (JsonRpc method p e r))
 
-    clientWithRoute _ _ req p =
-        client req jsonRpcRequest
+  hoistClientMonad _ _ f x p = f $ x p
 
-        where
-        client = clientWithRoute (Proxy @m) endpoint
-        jsonRpcRequest = Request (symbolVal $ Proxy @method) p (Just 0)
+instance
+  (RunClient m, KnownSymbol method, ToJSON p) =>
+  HasClient m (JsonRpcNotification method p)
+  where
+  type
+    Client m (JsonRpcNotification method p) =
+      p -> m NoContent
 
-        endpoint = Proxy @(JsonRpcEndpoint (JsonRpc method p e r))
+  clientWithRoute _ _ req p =
+    client req jsonRpcRequest
+   where
+    client = clientWithRoute (Proxy @m) endpoint
+    jsonRpcRequest = Request (symbolVal $ Proxy @method) p Nothing
 
-    hoistClientMonad _ _ f x p = f $ x p
+    endpoint = Proxy @(JsonRpcEndpoint (JsonRpcNotification method p))
 
-
-instance (RunClient m, KnownSymbol method, ToJSON p)
-    => HasClient m (JsonRpcNotification method p) where
-
-    type Client m (JsonRpcNotification method p)
-        = p -> m NoContent
-
-    clientWithRoute _ _ req p =
-        client req jsonRpcRequest
-        where
-        client = clientWithRoute (Proxy @m) endpoint
-        jsonRpcRequest = Request (symbolVal $ Proxy @method) p Nothing
-
-        endpoint = Proxy @(JsonRpcEndpoint (JsonRpcNotification method p))
-
-    hoistClientMonad _ _ f x p = f $ x p
+  hoistClientMonad _ _ f x p = f $ x p

--- a/servant-jsonrpc-examples/Setup.hs
+++ b/servant-jsonrpc-examples/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+
 main = defaultMain

--- a/servant-jsonrpc-examples/client/Main.hs
+++ b/servant-jsonrpc-examples/client/Main.hs
@@ -3,38 +3,40 @@
 
 module Main where
 
-import           Control.Monad           (void)
-import           Control.Monad.IO.Class  (liftIO)
-import           Data.Proxy              (Proxy (..))
-import           Network.HTTP.Client     (defaultManagerSettings, newManager)
-import           Servant.API             ((:<|>) (..), NoContent)
-import           Servant.Client          (ClientM, client, mkClientEnv,
-                                          parseBaseUrl, runClientM)
-import           Servant.Client.JsonRpc  (JsonRpcResponse)
-import           Servant.JsonRpc.Example (API, NonEndpoint)
-
+import Control.Monad (void)
+import Control.Monad.IO.Class (liftIO)
+import Data.Proxy (Proxy (..))
+import Network.HTTP.Client (defaultManagerSettings, newManager)
+import Servant.API (NoContent, (:<|>) (..))
+import Servant.Client (
+  ClientM,
+  client,
+  mkClientEnv,
+  parseBaseUrl,
+  runClientM,
+ )
+import Servant.Client.JsonRpc (JsonRpcResponse)
+import Servant.JsonRpc.Example (API, NonEndpoint)
 
 main :: IO ()
 main = do
-    env <- mkClientEnv <$> newManager defaultManagerSettings <*> parseBaseUrl "http://localhost:8080"
-    void . flip runClientM env $ do
-        jsonRpcPrint "Starting RPC calls"
-        liftIO . print =<< add (2, 10)
-        liftIO . print =<< multiply (2, 10)
+  env <- mkClientEnv <$> newManager defaultManagerSettings <*> parseBaseUrl "http://localhost:8080"
+  void . flip runClientM env $ do
+    jsonRpcPrint "Starting RPC calls"
+    liftIO . print =<< add (2, 10)
+    liftIO . print =<< multiply (2, 10)
 
-        printMessage "Starting REST calls"
-        liftIO . print =<< getTime
+    printMessage "Starting REST calls"
+    liftIO . print =<< getTime
 
-    -- A JSON-RPC error response
-    print =<< runClientM (launchMissiles 100) env
-
+  -- A JSON-RPC error response
+  print =<< runClientM (launchMissiles 100) env
 
 add, multiply :: (Int, Int) -> ClientM (JsonRpcResponse String Int)
 jsonRpcPrint :: String -> ClientM NoContent
 getTime :: ClientM String
 printMessage :: String -> ClientM NoContent
 (add :<|> multiply :<|> jsonRpcPrint) :<|> (getTime :<|> printMessage) = client $ Proxy @API
-
 
 launchMissiles :: Int -> ClientM (JsonRpcResponse String Bool)
 launchMissiles = client $ Proxy @NonEndpoint

--- a/servant-jsonrpc-examples/server/Main.hs
+++ b/servant-jsonrpc-examples/server/Main.hs
@@ -2,39 +2,36 @@
 
 module Main where
 
-import           Control.Monad.IO.Class   (liftIO)
-import           Data.Proxy               (Proxy (..))
-import           Data.Time                (defaultTimeLocale, formatTime,
-                                           getCurrentTime)
-import           Network.Wai.Handler.Warp (run)
-import           Servant.API              ((:<|>) (..), NoContent (..))
-import           Servant.Server           (Handler, Server, serve)
+import Control.Monad.IO.Class (liftIO)
+import Data.Proxy (Proxy (..))
+import Data.Time (
+  defaultTimeLocale,
+  formatTime,
+  getCurrentTime,
+ )
+import Network.Wai.Handler.Warp (run)
+import Servant.API (NoContent (..), (:<|>) (..))
+import Servant.Server (Handler, Server, serve)
 
-import           Servant.JsonRpc.Example  (API)
-import           Servant.Server.JsonRpc   (JsonRpcErr)
-
+import Servant.JsonRpc.Example (API)
+import Servant.Server.JsonRpc (JsonRpcErr)
 
 main :: IO ()
 main = run 8080 $ serve (Proxy @API) server
 
-
 server :: Server API
 server = (add :<|> multiply :<|> printMessage) :<|> (getTime :<|> printMessage)
-
 
 add :: (Int, Int) -> Handler (Either (JsonRpcErr String) Int)
 add = return . Right . uncurry (+)
 
-
 multiply :: (Int, Int) -> Handler (Either (JsonRpcErr String) Int)
 multiply = return . Right . uncurry (*)
-
 
 printMessage :: String -> Handler NoContent
 printMessage msg = NoContent <$ liftIO (putStrLn msg)
 
-
 getTime :: Handler String
 getTime = timeString <$> liftIO getCurrentTime
-    where
-    timeString = formatTime defaultTimeLocale "%T"
+ where
+  timeString = formatTime defaultTimeLocale "%T"

--- a/servant-jsonrpc-examples/src/Servant/JsonRpc/Example.hs
+++ b/servant-jsonrpc-examples/src/Servant/JsonRpc/Example.hs
@@ -1,35 +1,35 @@
-{-# LANGUAGE DataKinds     #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Servant.JsonRpc.Example
-    ( API
-    , NonEndpoint
-    ) where
+module Servant.JsonRpc.Example (
+  API,
+  NonEndpoint,
+) where
 
-import           Servant.API     ((:<|>) (..), (:>), Get, NoContent, PlainText,
-                                  Post, ReqBody)
-import           Servant.JsonRpc (JsonRpc, JsonRpcNotification, RawJsonRpc)
+import Servant.API (
+  Get,
+  NoContent,
+  PlainText,
+  Post,
+  ReqBody,
+  (:<|>) (..),
+  (:>),
+ )
+import Servant.JsonRpc (JsonRpc, JsonRpcNotification, RawJsonRpc)
 
-
-type Add      = JsonRpc "add"      (Int, Int) String Int
+type Add = JsonRpc "add" (Int, Int) String Int
 type Multiply = JsonRpc "multiply" (Int, Int) String Int
-type Print    = JsonRpcNotification "print" String
-
+type Print = JsonRpcNotification "print" String
 
 type RpcAPI = Add :<|> Multiply :<|> Print
 
-
 type JsonRpcAPI = "json-rpc" :> RawJsonRpc RpcAPI
-
 
 type GetTime = "time" :> Get '[PlainText] String
 type PrintMessage = "print" :> ReqBody '[PlainText] String :> Post '[PlainText] NoContent
 
-
 type RestAPI = "rest" :> (GetTime :<|> PrintMessage)
 
-
 type API = JsonRpcAPI :<|> RestAPI
-
 
 type NonEndpoint = "json-rpc" :> RawJsonRpc (JsonRpc "launch-missles" Int String Bool)

--- a/servant-jsonrpc-server/Setup.hs
+++ b/servant-jsonrpc-server/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+
 main = defaultMain

--- a/servant-jsonrpc-server/src/Servant/Server/JsonRpc.hs
+++ b/servant-jsonrpc-server/src/Servant/Server/JsonRpc.hs
@@ -1,14 +1,14 @@
-{-# LANGUAGE CPP                   #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 #if MIN_VERSION_servant_server(0,18,0)
 {-# LANGUAGE UndecidableInstances  #-}
@@ -16,169 +16,178 @@
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
--- |
--- Module: Servant.Server.JsonRpc
---
--- This module provides support for writing handlers for JSON-RPC endpoints
---
--- > type Mul = JsonRpc "mul" (Int, Int) String Int
--- > mulHandler :: (Int, Int) -> Handler (Either (JsonRpcErr String) Int)
--- > mulHandler = _
---
--- > type Add = JsonRpc "add" (Int, Int) String Int
--- > addHandler :: (Int, Int) -> Handler (Either (JsonRpcErr String) Int)
--- > addHandler = _
---
--- > type API = Add :<|> Mul
--- > server :: Application
--- > server = serve (Proxy @(RawJsonRpc API)) $ addHandler :<|> mulHandler
-module Servant.Server.JsonRpc
-    ( serveJsonRpc
-    , RouteJsonRpc (..)
-    , module Servant.JsonRpc
-    , PossibleContent
-    , PossibleJsonRpcResponse
-    ) where
+{- |
+Module: Servant.Server.JsonRpc
 
-import           Data.Aeson               (FromJSON (..), ToJSON (..), Value)
-import           Data.Aeson.Types         (parseEither)
-import           Data.Bifunctor           (bimap)
-import           Data.Kind                (Type)
-import           Data.Map.Strict          (Map)
-import qualified Data.Map.Strict          as Map
-import           Data.Proxy               (Proxy (..))
-import           GHC.TypeLits             (KnownSymbol, symbolVal)
-import           Servant.API              (NoContent (..), Post, ReqBody,
-                                           (:<|>) (..), (:>))
-import           Servant.API.ContentTypes (AllCTRender (..))
+This module provides support for writing handlers for JSON-RPC endpoints
+
+> type Mul = JsonRpc "mul" (Int, Int) String Int
+> mulHandler :: (Int, Int) -> Handler (Either (JsonRpcErr String) Int)
+> mulHandler = _
+
+> type Add = JsonRpc "add" (Int, Int) String Int
+> addHandler :: (Int, Int) -> Handler (Either (JsonRpcErr String) Int)
+> addHandler = _
+
+> type API = Add :<|> Mul
+> server :: Application
+> server = serve (Proxy @(RawJsonRpc API)) $ addHandler :<|> mulHandler
+-}
+module Servant.Server.JsonRpc (
+  serveJsonRpc,
+  RouteJsonRpc (..),
+  module Servant.JsonRpc,
+  PossibleContent,
+  PossibleJsonRpcResponse,
+) where
+
+import Data.Aeson (FromJSON (..), ToJSON (..), Value)
+import Data.Aeson.Types (parseEither)
+import Data.Bifunctor (bimap)
+import Data.Kind (Type)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Proxy (Proxy (..))
+import GHC.TypeLits (KnownSymbol, symbolVal)
+import Servant.API (
+  NoContent (..),
+  Post,
+  ReqBody,
+  (:<|>) (..),
+  (:>),
+ )
+import Servant.API.ContentTypes (AllCTRender (..))
 
 #if MIN_VERSION_servant_server(0,18,0)
-import           Servant.Server           (DefaultErrorFormatters,
-                                           ErrorFormatters, Handler,
-                                           HasContextEntry, HasServer (..),
-                                           type (.++))
+import Servant.Server (
+  DefaultErrorFormatters,
+  ErrorFormatters,
+  Handler,
+  HasContextEntry,
+  HasServer (..),
+  type (.++),
+ )
 #elif MIN_VERSION_servant_server(0,14,0)
-import           Servant.Server           (Handler, HasServer (..))
+import Servant.Server (Handler, HasServer (..))
 #endif
 
-import           Servant.JsonRpc
+import Servant.JsonRpc
 
-
--- | Since we collapse an entire JSON RPC api down to a single Servant
---   endpoint, we need a type that /can/ return content but might not.
+{- | Since we collapse an entire JSON RPC api down to a single Servant
+  endpoint, we need a type that /can/ return content but might not.
+-}
 data PossibleContent a = SomeContent a | EmptyContent
 
-
-instance ToJSON a => AllCTRender '[JSONRPC] (PossibleContent a) where
-    handleAcceptH px h = \case
-        SomeContent x -> handleAcceptH px h x
-        EmptyContent  -> handleAcceptH px h NoContent
-
+instance (ToJSON a) => AllCTRender '[JSONRPC] (PossibleContent a) where
+  handleAcceptH px h = \case
+    SomeContent x -> handleAcceptH px h x
+    EmptyContent -> handleAcceptH px h NoContent
 
 type PossibleJsonRpcResponse = PossibleContent (JsonRpcResponse Value Value)
 
-
-type RawJsonRpcEndpoint
-    = ReqBody '[JSONRPC] (Request Value)
-   :> Post '[JSONRPC] PossibleJsonRpcResponse
-
+type RawJsonRpcEndpoint =
+  ReqBody '[JSONRPC] (Request Value)
+    :> Post '[JSONRPC] PossibleJsonRpcResponse
 
 #if MIN_VERSION_servant_server(0,18,0)
-instance (RouteJsonRpc api, HasContextEntry (context .++ DefaultErrorFormatters) ErrorFormatters) => HasServer (RawJsonRpc api) context where
+instance
+  (RouteJsonRpc api, HasContextEntry (context .++ DefaultErrorFormatters) ErrorFormatters) =>
+  HasServer (RawJsonRpc api) context
+  where
 #elif MIN_VERSION_servant_server(0,14,0)
-instance RouteJsonRpc api => HasServer (RawJsonRpc api) context where
+  instance (RouteJsonRpc api) => HasServer (RawJsonRpc api) context where
 #endif
-    type ServerT (RawJsonRpc api) m = RpcHandler api m
-    route _ cx = route endpoint cx . fmap (serveJsonRpc pxa pxh)
-        where
-        endpoint = Proxy @RawJsonRpcEndpoint
-        pxa      = Proxy @api
-        pxh      = Proxy @Handler
+  type ServerT (RawJsonRpc api) m = RpcHandler api m
+  route _ cx = route endpoint cx . fmap (serveJsonRpc pxa pxh)
+   where
+    endpoint = Proxy @RawJsonRpcEndpoint
+    pxa = Proxy @api
+    pxh = Proxy @Handler
 
-    hoistServerWithContext _ _ f x = hoistRpcRouter (Proxy @api) f x
-
+  hoistServerWithContext _ _ f x = hoistRpcRouter (Proxy @api) f x
 
 -- | This internal class is how we accumulate a map of handlers for dispatch
 class RouteJsonRpc a where
-    type RpcHandler a (m :: Type -> Type)
-    jsonRpcRouter
-        :: Monad m => Proxy a -> Proxy m -> RpcHandler a m
-        -> Map String (Value -> m (PossibleContent (Either (JsonRpcErr Value) Value)))
-    hoistRpcRouter :: Proxy a -> (forall x . m x -> n x) -> RpcHandler a m -> RpcHandler a n
+  type RpcHandler a (m :: Type -> Type)
+  jsonRpcRouter ::
+    (Monad m) =>
+    Proxy a ->
+    Proxy m ->
+    RpcHandler a m ->
+    Map String (Value -> m (PossibleContent (Either (JsonRpcErr Value) Value)))
+  hoistRpcRouter :: Proxy a -> (forall x. m x -> n x) -> RpcHandler a m -> RpcHandler a n
 
-
-generalizeResponse
-    :: (ToJSON e, ToJSON r)
-    => Either (JsonRpcErr e) r
-    -> Either (JsonRpcErr Value) Value
+generalizeResponse ::
+  (ToJSON e, ToJSON r) =>
+  Either (JsonRpcErr e) r ->
+  Either (JsonRpcErr Value) Value
 generalizeResponse = bimap repack toJSON
-    where
-    repack e = e { errorData = toJSON <$> errorData e }
-
+ where
+  repack e = e{errorData = toJSON <$> errorData e}
 
 onDecodeFail :: String -> JsonRpcErr e
 onDecodeFail msg = JsonRpcErr invalidParamsCode msg Nothing
 
-
 instance (KnownSymbol method, FromJSON p, ToJSON e, ToJSON r) => RouteJsonRpc (JsonRpc method p e r) where
-    type RpcHandler (JsonRpc method p e r) m = p -> m (Either (JsonRpcErr e) r)
+  type RpcHandler (JsonRpc method p e r) m = p -> m (Either (JsonRpcErr e) r)
 
-    jsonRpcRouter _ _ h = Map.fromList [ (methodName, h') ]
-        where
-        methodName = symbolVal $ Proxy @method
-        onDecode   = fmap generalizeResponse . h
+  jsonRpcRouter _ _ h = Map.fromList [(methodName, h')]
+   where
+    methodName = symbolVal $ Proxy @method
+    onDecode = fmap generalizeResponse . h
 
-        h' = fmap SomeContent
-           . either (return . Left . onDecodeFail) onDecode
-           . parseEither parseJSON
+    h' =
+      fmap SomeContent
+        . either (return . Left . onDecodeFail) onDecode
+        . parseEither parseJSON
 
-    hoistRpcRouter _ f x = f . x
-
+  hoistRpcRouter _ f x = f . x
 
 instance (KnownSymbol method, FromJSON p) => RouteJsonRpc (JsonRpcNotification method p) where
-    type RpcHandler (JsonRpcNotification method p) m = p -> m NoContent
+  type RpcHandler (JsonRpcNotification method p) m = p -> m NoContent
 
-    jsonRpcRouter _ _ h = Map.fromList [ (methodName, h') ]
-        where
-        methodName = symbolVal $ Proxy @method
-        onDecode x = EmptyContent <$ h x
+  jsonRpcRouter _ _ h = Map.fromList [(methodName, h')]
+   where
+    methodName = symbolVal $ Proxy @method
+    onDecode x = EmptyContent <$ h x
 
-        h' = either (return . SomeContent . Left . onDecodeFail) onDecode
-           . parseEither parseJSON
+    h' =
+      either (return . SomeContent . Left . onDecodeFail) onDecode
+        . parseEither parseJSON
 
-    hoistRpcRouter _ f x = f . x
-
+  hoistRpcRouter _ f x = f . x
 
 instance (RouteJsonRpc a, RouteJsonRpc b) => RouteJsonRpc (a :<|> b) where
-    type RpcHandler (a :<|> b) m = RpcHandler a m :<|> RpcHandler b m
+  type RpcHandler (a :<|> b) m = RpcHandler a m :<|> RpcHandler b m
 
-    jsonRpcRouter _ pxm (ha :<|> hb) = jsonRpcRouter pxa pxm ha <> jsonRpcRouter pxb pxm hb
-        where
-        pxa = Proxy @a
-        pxb = Proxy @b
+  jsonRpcRouter _ pxm (ha :<|> hb) = jsonRpcRouter pxa pxm ha <> jsonRpcRouter pxb pxm hb
+   where
+    pxa = Proxy @a
+    pxb = Proxy @b
 
-    hoistRpcRouter _ f (x :<|> y) = hoistRpcRouter (Proxy @a) f x :<|> hoistRpcRouter (Proxy @b) f y
+  hoistRpcRouter _ f (x :<|> y) = hoistRpcRouter (Proxy @a) f x :<|> hoistRpcRouter (Proxy @b) f y
 
-
--- | This function is the glue required to convert a collection of
--- handlers in servant standard style to the handler that 'RawJsonRpc'
--- expects.
-serveJsonRpc
-    :: (Monad m, RouteJsonRpc a)
-    => Proxy a
-    -> Proxy m
-    -> RpcHandler a m
-    -> Request Value
-    -> m PossibleJsonRpcResponse
+{- | This function is the glue required to convert a collection of
+handlers in servant standard style to the handler that 'RawJsonRpc'
+expects.
+-}
+serveJsonRpc ::
+  (Monad m, RouteJsonRpc a) =>
+  Proxy a ->
+  Proxy m ->
+  RpcHandler a m ->
+  Request Value ->
+  m PossibleJsonRpcResponse
 serveJsonRpc px pxm hs (Request m v ix')
-    | Just h <- Map.lookup m hmap
-    = h v >>= \case
-        SomeContent (Right x) | Just ix <- ix' -> return . SomeContent $ Result ix x
-                              | otherwise      -> return . SomeContent $ Errors ix' invalidRequest
-        SomeContent (Left e)                   -> return . SomeContent $ Errors ix' e
-        EmptyContent                           -> return EmptyContent
-    | otherwise = return . SomeContent $ Errors ix' missingMethod
-    where
-    missingMethod  = JsonRpcErr methodNotFoundCode ("Unknown method: " <> m) Nothing
-    hmap           = jsonRpcRouter px pxm hs
-    invalidRequest = JsonRpcErr invalidRequestCode "Missing id" Nothing
+  | Just h <- Map.lookup m hmap =
+      h v >>= \case
+        SomeContent (Right x)
+          | Just ix <- ix' -> return . SomeContent $ Result ix x
+          | otherwise -> return . SomeContent $ Errors ix' invalidRequest
+        SomeContent (Left e) -> return . SomeContent $ Errors ix' e
+        EmptyContent -> return EmptyContent
+  | otherwise = return . SomeContent $ Errors ix' missingMethod
+ where
+  missingMethod = JsonRpcErr methodNotFoundCode ("Unknown method: " <> m) Nothing
+  hmap = jsonRpcRouter px pxm hs
+  invalidRequest = JsonRpcErr invalidRequestCode "Missing id" Nothing

--- a/servant-jsonrpc/Setup.hs
+++ b/servant-jsonrpc/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+
 main = defaultMain

--- a/servant-jsonrpc/src/Servant/JsonRpc.hs
+++ b/servant-jsonrpc/src/Servant/JsonRpc.hs
@@ -1,221 +1,216 @@
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 
--- |
--- Module: Servant.JsonRpc
---
--- Work with JSON-RPC protocol messages at both type and value level.
---
--- > type Mul = JsonRpc "mul" (Int, Int) String Int
--- >
--- > req :: Request (Int, Int)
--- > req = Request "mul" (3, 5) (Just 0)
--- >
--- > rsp :: JsonRpcResponse String Int
--- > rsp = Result 0 15
-module Servant.JsonRpc
-    (
-    -- * API specification types
-      RawJsonRpc
-    , JsonRpc
-    , JsonRpcNotification
-    , JSONRPC
+{- |
+Module: Servant.JsonRpc
 
-    -- * JSON-RPC messages
-    , Request (..)
-    , JsonRpcResponse (..)
-    , JsonRpcErr (..)
+Work with JSON-RPC protocol messages at both type and value level.
 
-    -- ** Standard error codes
-    , parseErrorCode
-    , invalidRequestCode
-    , methodNotFoundCode
-    , invalidParamsCode
-    , internalErrorCode
+> type Mul = JsonRpc "mul" (Int, Int) String Int
+>
+> req :: Request (Int, Int)
+> req = Request "mul" (3, 5) (Just 0)
+>
+> rsp :: JsonRpcResponse String Int
+> rsp = Result 0 15
+-}
+module Servant.JsonRpc (
+  -- * API specification types
+  RawJsonRpc,
+  JsonRpc,
+  JsonRpcNotification,
+  JSONRPC,
 
-    -- * Type rewriting
-    , JsonRpcEndpoint
-    ) where
+  -- * JSON-RPC messages
+  Request (..),
+  JsonRpcResponse (..),
+  JsonRpcErr (..),
 
+  -- ** Standard error codes
+  parseErrorCode,
+  invalidRequestCode,
+  methodNotFoundCode,
+  invalidParamsCode,
+  internalErrorCode,
 
-import           Control.Applicative (liftA3, (<|>))
-import           Data.Aeson          (FromJSON (..), ToJSON (..), Value (Null),
-                                      object, withObject, (.:), (.:?), (.=))
-import           Data.Aeson.Types    (Parser)
-import           Data.List.NonEmpty  (NonEmpty (..))
-import           Data.Maybe          (isNothing)
-import           Data.Proxy          (Proxy (..))
-import           Data.Text.Read      (decimal)
-import           Data.Word           (Word64)
-import           GHC.TypeLits        (Symbol)
-import           Network.HTTP.Media  ((//))
-import           Servant.API         (Accept (..), JSON, MimeRender (..),
-                                      MimeUnrender (..), NoContent, Post,
-                                      ReqBody, (:>))
+  -- * Type rewriting
+  JsonRpcEndpoint,
+) where
 
+import Control.Applicative (liftA3, (<|>))
+import Data.Aeson (
+  FromJSON (..),
+  ToJSON (..),
+  Value (Null),
+  object,
+  withObject,
+  (.:),
+  (.:?),
+  (.=),
+ )
+import Data.Aeson.Types (Parser)
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.Maybe (isNothing)
+import Data.Proxy (Proxy (..))
+import Data.Text.Read (decimal)
+import Data.Word (Word64)
+import GHC.TypeLits (Symbol)
+import Network.HTTP.Media ((//))
+import Servant.API (
+  Accept (..),
+  JSON,
+  MimeRender (..),
+  MimeUnrender (..),
+  NoContent,
+  Post,
+  ReqBody,
+  (:>),
+ )
 
 -- | Client messages
 data Request p
-    = Request
-    { method    :: String
-    , params    :: p
+  = Request
+  { method :: String
+  , params :: p
+  , requestId :: Maybe Word64
+  -- ^ should be omitted only if the message is a notification, with no response content
+  }
+  deriving (Eq, Show)
 
-    -- | should be omitted only if the message is a notification, with no response content
-    , requestId :: Maybe Word64
-    } deriving (Eq, Show)
+instance (ToJSON p) => ToJSON (Request p) where
+  toJSON (Request m p ix) =
+    object
+      . maybe id (onValue "id") ix
+      $ [ "jsonrpc" .= ("2.0" :: String)
+        , "method" .= m
+        , "params" .= p
+        ]
+   where
+    onValue n v = ((n .= v) :)
 
+instance (FromJSON p) => FromJSON (Request p) where
+  parseJSON = withObject "JsonRpc Request" $ \obj -> do
+    ix <- obj .:? "id"
+    m <- obj .: "method"
+    p <- obj .: "params"
+    v <- obj .: "jsonrpc"
 
-instance ToJSON p => ToJSON (Request p) where
-    toJSON (Request m p ix) =
-        object
-            . maybe id (onValue "id") ix
-            $ [ "jsonrpc" .= ("2.0" :: String)
-              , "method" .= m
-              , "params" .= p
-              ]
-
-        where
-        onValue n v = ((n .= v) :)
-
-
-instance FromJSON p => FromJSON (Request p) where
-    parseJSON = withObject "JsonRpc Request" $ \obj -> do
-        ix <- obj .:? "id"
-        m  <- obj .:  "method"
-        p  <- obj .:  "params"
-        v  <- obj .:  "jsonrpc"
-
-        versionGuard v . pure $ Request m p ix
-
+    versionGuard v . pure $ Request m p ix
 
 versionGuard :: Maybe String -> Parser a -> Parser a
 versionGuard v x
-    | v == Just "2.0" = x
-    | isNothing v     = x
-    | otherwise       = fail "unknown version"
+  | v == Just "2.0" = x
+  | isNothing v = x
+  | otherwise = fail "unknown version"
 
-
--- | Server messages.  An 'Ack' is a message which refers to a 'Request' but
--- both its "errors" and "result" keys are null
+{- | Server messages.  An 'Ack' is a message which refers to a 'Request' but
+both its "errors" and "result" keys are null
+-}
 data JsonRpcResponse e r
-    = Result Word64 r
-    | Ack Word64
-    | Errors (Maybe Word64) (JsonRpcErr e)
-    deriving (Eq, Show)
-
+  = Result Word64 r
+  | Ack Word64
+  | Errors (Maybe Word64) (JsonRpcErr e)
+  deriving (Eq, Show)
 
 data JsonRpcErr e = JsonRpcErr
-    { errorCode    :: Int
-    , errorMessage :: String
-    , errorData    :: Maybe e
-    } deriving (Eq, Show)
-
+  { errorCode :: Int
+  , errorMessage :: String
+  , errorData :: Maybe e
+  }
+  deriving (Eq, Show)
 
 parseErrorCode :: Int
 parseErrorCode = -32700
 
-
 invalidRequestCode :: Int
 invalidRequestCode = -32600
-
 
 methodNotFoundCode :: Int
 methodNotFoundCode = -32601
 
-
 invalidParamsCode :: Int
 invalidParamsCode = -32602
-
 
 internalErrorCode :: Int
 internalErrorCode = -32603
 
-
 instance (FromJSON e, FromJSON r) => FromJSON (JsonRpcResponse e r) where
-    parseJSON = withObject "Response" $ \obj -> do
-        ix      <- obj .:  "id" <|> (obj .: "id" >>= parseDecimalString)
-        version <- obj .:? "jsonrpc"
-        result  <- obj .:? "result"
-        err     <- obj .:? "error"
-        versionGuard version $ pack ix result err
+  parseJSON = withObject "Response" $ \obj -> do
+    ix <- obj .: "id" <|> (obj .: "id" >>= parseDecimalString)
+    version <- obj .:? "jsonrpc"
+    result <- obj .:? "result"
+    err <- obj .:? "error"
+    versionGuard version $ pack ix result err
+   where
+    parseDecimalString = either fail (pure . fmap fst) . traverse decimal
 
-        where
+    pack (Just ix) (Just r) Nothing = pure $ Result ix r
+    pack ix Nothing (Just e) = Errors ix <$> parseErr e
+    pack (Just ix) Nothing Nothing = pure $ Ack ix
+    pack _ _ _ = fail "invalid response"
 
-        parseDecimalString = either fail (pure . fmap fst) . traverse decimal
-
-        pack (Just ix) (Just r) Nothing = pure $ Result ix r
-        pack ix Nothing (Just e)        = Errors ix <$> parseErr e
-        pack (Just ix) Nothing Nothing  = pure $ Ack ix
-        pack _ _ _                      = fail "invalid response"
-
-        parseErr = withObject "Error" $
-            liftA3 JsonRpcErr <$> (.: "code") <*> (.: "message") <*> (.:? "data")
-
+    parseErr =
+      withObject "Error" $
+        liftA3 JsonRpcErr <$> (.: "code") <*> (.: "message") <*> (.:? "data")
 
 instance (ToJSON e, ToJSON r) => ToJSON (JsonRpcResponse e r) where
-    toJSON (Result ix r) =
-        object [ "jsonrpc" .= ("2.0" :: String)
-               , "result"  .= r
-               , "id"      .= ix
-               ]
-
-    toJSON (Ack ix) =
-        object [ "jsonrpc" .= ("2.0" :: String)
-               , "id"      .= ix
-               , "result"  .= Null
-               , "error"   .= Null
-               ]
-
-    toJSON (Errors ix (JsonRpcErr c msg err)) =
-        object [ "jsonrpc" .= ("2.0" :: String)
-               , "id"      .= ix
-               , "error"   .= detail
-               ]
-
-         where
-         detail = object [ "code"    .= c
-                         , "message" .= msg
-                         , "data"    .= err
-                         ]
-
+  toJSON (Result ix r) =
+    object
+      [ "jsonrpc" .= ("2.0" :: String)
+      , "result" .= r
+      , "id" .= ix
+      ]
+  toJSON (Ack ix) =
+    object
+      [ "jsonrpc" .= ("2.0" :: String)
+      , "id" .= ix
+      , "result" .= Null
+      , "error" .= Null
+      ]
+  toJSON (Errors ix (JsonRpcErr c msg err)) =
+    object
+      [ "jsonrpc" .= ("2.0" :: String)
+      , "id" .= ix
+      , "error" .= detail
+      ]
+   where
+    detail =
+      object
+        [ "code" .= c
+        , "message" .= msg
+        , "data" .= err
+        ]
 
 -- | A JSON RPC server handles any number of methods.  Represent this at the type level using this type.
 data RawJsonRpc api
 
-
 -- | JSON-RPC endpoints which respond with a result
 data JsonRpc (method :: Symbol) p e r
-
 
 -- | JSON-RPC endpoints which do not respond
 data JsonRpcNotification (method :: Symbol) p
 
-
 type family JsonRpcEndpoint a where
-    JsonRpcEndpoint (JsonRpc m p e r)
-        = ReqBody '[JSONRPC] (Request p) :> Post '[JSONRPC] (JsonRpcResponse e r)
-
-    JsonRpcEndpoint (JsonRpcNotification m p)
-        = ReqBody '[JSONRPC] (Request p) :> Post '[JSONRPC] NoContent
+  JsonRpcEndpoint (JsonRpc m p e r) =
+    ReqBody '[JSONRPC] (Request p) :> Post '[JSONRPC] (JsonRpcResponse e r)
+  JsonRpcEndpoint (JsonRpcNotification m p) =
+    ReqBody '[JSONRPC] (Request p) :> Post '[JSONRPC] NoContent
 
 -- | The JSON-RPC content type
 data JSONRPC
 
-
 instance Accept JSONRPC where
-    contentTypes _ = "application" // "json-rpc" :| ["application" // "json"]
+  contentTypes _ = "application" // "json-rpc" :| ["application" // "json"]
 
+instance (ToJSON a) => MimeRender JSONRPC a where
+  mimeRender _ = mimeRender (Proxy @JSON)
 
-instance ToJSON a => MimeRender JSONRPC a where
-    mimeRender _ = mimeRender (Proxy @JSON)
-
-
-instance FromJSON a => MimeUnrender JSONRPC a where
-    mimeUnrender _ = mimeUnrender (Proxy @JSON)
+instance (FromJSON a) => MimeUnrender JSONRPC a where
+  mimeUnrender _ = mimeUnrender (Proxy @JSON)


### PR DESCRIPTION
This change formats the code with `fourmolu` instead of `stylish-haskell`.