### PR TITLE
Handle content types more flexibly

### DIFF
--- a/servant-jsonrpc-client/servant-jsonrpc-client.cabal
+++ b/servant-jsonrpc-client/servant-jsonrpc-client.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.4
 
 name:                servant-jsonrpc-client
-version:             1.1.0
+version:             1.2.0
 author:              Ian Shipman <ics@gambolingpangolin.com>
 maintainer:          Ian Shipman <ics@gambolingpangolin.com>
 
@@ -34,4 +34,4 @@ library
     , base                          >= 4.11         && < 5.0
     , servant                       >= 0.14         && < 0.21
     , servant-client-core           >= 0.14         && < 0.21
-    , servant-jsonrpc               >= 1.0.1        && < 1.2
+    , servant-jsonrpc               >= 1.2          && < 1.3

--- a/servant-jsonrpc-client/src/Servant/Client/JsonRpc.hs
+++ b/servant-jsonrpc-client/src/Servant/Client/JsonRpc.hs
@@ -1,8 +1,11 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 {- |
@@ -21,26 +24,32 @@ module Servant.Client.JsonRpc (
   module Servant.JsonRpc,
 ) where
 
-import Data.Aeson (FromJSON, ToJSON)
 import Data.Proxy (Proxy (..))
 import GHC.TypeLits (KnownSymbol, symbolVal)
-import Servant.API (NoContent)
+import Servant.API (MimeRender, MimeUnrender, NoContent, (:<|>))
 import Servant.Client.Core (HasClient (..), RunClient)
 
 import Servant.JsonRpc
 
 -- | The 'RawJsonRpc' construct is completely transparent to clients
-instance (RunClient m, HasClient m api) => HasClient m (RawJsonRpc api) where
-  type Client m (RawJsonRpc api) = Client m api
-  clientWithRoute pxm _ = clientWithRoute pxm (Proxy @api)
-  hoistClientMonad pxm _ = hoistClientMonad pxm (Proxy @api)
+instance
+  (RunClient m, HasClient m (RawJsonRpc ctype apiL), HasClient m (RawJsonRpc ctype apiR)) =>
+  HasClient m (RawJsonRpc ctype (apiL :<|> apiR))
+  where
+  type Client m (RawJsonRpc ctype (apiL :<|> apiR)) = Client m (RawJsonRpc ctype apiL :<|> RawJsonRpc ctype apiR)
+  clientWithRoute pxm _ = clientWithRoute pxm (Proxy @(RawJsonRpc ctype apiL :<|> RawJsonRpc ctype apiR))
+  hoistClientMonad pxm _ = hoistClientMonad pxm (Proxy @(RawJsonRpc ctype apiL :<|> RawJsonRpc ctype apiR))
 
 instance
-  (RunClient m, KnownSymbol method, ToJSON p, FromJSON e, FromJSON r) =>
-  HasClient m (JsonRpc method p e r)
+  ( RunClient m
+  , KnownSymbol method
+  , MimeRender ctype (Request p)
+  , MimeUnrender ctype (JsonRpcResponse e r)
+  ) =>
+  HasClient m (RawJsonRpc ctype (JsonRpc method p e r))
   where
   type
-    Client m (JsonRpc method p e r) =
+    Client m (RawJsonRpc ctype (JsonRpc method p e r)) =
       p -> m (JsonRpcResponse e r)
 
   clientWithRoute _ _ req p =
@@ -49,16 +58,19 @@ instance
     client = clientWithRoute (Proxy @m) endpoint
     jsonRpcRequest = Request (symbolVal $ Proxy @method) p (Just 0)
 
-    endpoint = Proxy @(JsonRpcEndpoint (JsonRpc method p e r))
+    endpoint = Proxy @(JsonRpcEndpoint ctype (JsonRpc method p e r))
 
   hoistClientMonad _ _ f x p = f $ x p
 
 instance
-  (RunClient m, KnownSymbol method, ToJSON p) =>
-  HasClient m (JsonRpcNotification method p)
+  ( RunClient m
+  , KnownSymbol method
+  , MimeRender ctype (Request p)
+  ) =>
+  HasClient m (RawJsonRpc ctype (JsonRpcNotification method p))
   where
   type
-    Client m (JsonRpcNotification method p) =
+    Client m (RawJsonRpc ctype (JsonRpcNotification method p)) =
       p -> m NoContent
 
   clientWithRoute _ _ req p =
@@ -67,6 +79,6 @@ instance
     client = clientWithRoute (Proxy @m) endpoint
     jsonRpcRequest = Request (symbolVal $ Proxy @method) p Nothing
 
-    endpoint = Proxy @(JsonRpcEndpoint (JsonRpcNotification method p))
+    endpoint = Proxy @(JsonRpcEndpoint ctype (JsonRpcNotification method p))
 
   hoistClientMonad _ _ f x p = f $ x p

--- a/servant-jsonrpc-examples/src/Servant/JsonRpc/Example.hs
+++ b/servant-jsonrpc-examples/src/Servant/JsonRpc/Example.hs
@@ -15,7 +15,7 @@ import Servant.API (
   (:<|>) (..),
   (:>),
  )
-import Servant.JsonRpc (JsonRpc, JsonRpcNotification, RawJsonRpc)
+import Servant.JsonRpc (JSONRPC, JsonRpc, JsonRpcNotification, RawJsonRpc)
 
 type Add = JsonRpc "add" (Int, Int) String Int
 type Multiply = JsonRpc "multiply" (Int, Int) String Int
@@ -23,7 +23,7 @@ type Print = JsonRpcNotification "print" String
 
 type RpcAPI = Add :<|> Multiply :<|> Print
 
-type JsonRpcAPI = "json-rpc" :> RawJsonRpc RpcAPI
+type JsonRpcAPI = "json-rpc" :> RawJsonRpc JSONRPC RpcAPI
 
 type GetTime = "time" :> Get '[PlainText] String
 type PrintMessage = "print" :> ReqBody '[PlainText] String :> Post '[PlainText] NoContent
@@ -32,4 +32,4 @@ type RestAPI = "rest" :> (GetTime :<|> PrintMessage)
 
 type API = JsonRpcAPI :<|> RestAPI
 
-type NonEndpoint = "json-rpc" :> RawJsonRpc (JsonRpc "launch-missles" Int String Bool)
+type NonEndpoint = "json-rpc" :> RawJsonRpc JSONRPC (JsonRpc "launch-missles" Int String Bool)

--- a/servant-jsonrpc-server/servant-jsonrpc-server.cabal
+++ b/servant-jsonrpc-server/servant-jsonrpc-server.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.4
 
 name:                servant-jsonrpc-server
-version:             2.1.2
+version:             2.2.0
 author:              Ian Shipman <ics@gambolingpangolin.com>
 maintainer:          Ian Shipman <ics@gambolingpangolin.com>
 
@@ -34,5 +34,5 @@ library
     , base                  >= 4.11         && < 5.0
     , containers            >= 0.5          && < 0.7
     , servant               >= 0.14         && < 0.21
-    , servant-jsonrpc       >= 1.0.1        && < 1.2
+    , servant-jsonrpc       >= 1.2          && < 1.3
     , servant-server        >= 0.14         && < 0.21

--- a/servant-jsonrpc/servant-jsonrpc.cabal
+++ b/servant-jsonrpc/servant-jsonrpc.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.4
 
 name:                servant-jsonrpc
-version:             1.1.1
+version:             1.2.0
 author:              Ian Shipman <ics@gambolingpangolin.com>
 maintainer:          Ian Shipman <ics@gambolingpangolin.com>
 

--- a/servant-jsonrpc/src/Servant/JsonRpc.hs
+++ b/servant-jsonrpc/src/Servant/JsonRpc.hs
@@ -189,7 +189,7 @@ instance (ToJSON e, ToJSON r) => ToJSON (JsonRpcResponse e r) where
         ]
 
 -- | A JSON RPC server handles any number of methods.  Represent this at the type level using this type.
-data RawJsonRpc api
+data RawJsonRpc ctype api
 
 -- | JSON-RPC endpoints which respond with a result
 data JsonRpc (method :: Symbol) p e r
@@ -197,11 +197,11 @@ data JsonRpc (method :: Symbol) p e r
 -- | JSON-RPC endpoints which do not respond
 data JsonRpcNotification (method :: Symbol) p
 
-type family JsonRpcEndpoint a where
-  JsonRpcEndpoint (JsonRpc m p e r) =
-    ReqBody '[JSONRPC] (Request p) :> Post '[JSONRPC] (JsonRpcResponse e r)
-  JsonRpcEndpoint (JsonRpcNotification m p) =
-    ReqBody '[JSONRPC] (Request p) :> Post '[JSONRPC] NoContent
+type family JsonRpcEndpoint ctype a where
+  JsonRpcEndpoint ctype (JsonRpc m p e r) =
+    ReqBody '[ctype] (Request p) :> Post '[ctype] (JsonRpcResponse e r)
+  JsonRpcEndpoint ctype (JsonRpcNotification m p) =
+    ReqBody '[ctype] (Request p) :> Post '[ctype] NoContent
 
 -- | The JSON-RPC content type
 data JSONRPC


### PR DESCRIPTION
Inspired by #8 this change allows the developer using the library to control the content type used by the client.  I have some appetite to do a breaking change here to keep the size of the library as small as possible.  So I changed the type `RawJsonRpc` to take an explicit content type parameter.

This also addresses #9 

@edsko great work on your patch!  Sorry I ignored it for so long.  I made you a co-author on this change.

This patch also makes the server more flexible.  It can accept and respond with either `application/json` or `application/json-rpc` as instructed by client headers.